### PR TITLE
Include generated ai.txt docs in createLocalCircuitPrompt

### DIFF
--- a/lib/prompt-templates/create-local-circuit-prompt.ts
+++ b/lib/prompt-templates/create-local-circuit-prompt.ts
@@ -14,8 +14,8 @@ async function fetchFileContent(url: string): Promise<string> {
     }
     return await response.text()
   } catch (error) {
-    console.error("Error fetching file content:", error)
-    throw error
+    console.warn(`Unable to fetch ${url}:`, error)
+    return ""
   }
 }
 
@@ -33,10 +33,17 @@ export const createLocalCircuitPrompt = async () => {
     "",
   )
 
-  const propsDoc =
-    (await fetchFileContent(
+  const [generatedAiDoc, propsDoc] = await Promise.all([
+    fetchFileContent("https://docs.tscircuit.com/ai.txt"),
+    fetchFileContent(
       "https://raw.githubusercontent.com/tscircuit/props/main/generated/COMPONENT_TYPES.md",
-    )) || ""
+    ),
+  ])
+
+  const cleanedGeneratedAiDoc = generatedAiDoc
+    .replace(/\r/g, "")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim()
 
   const cleanedPropsDoc = propsDoc
     .split("\n")
@@ -44,10 +51,16 @@ export const createLocalCircuitPrompt = async () => {
     .join("\n")
     .replace(/\n\n+/g, "\n\n")
 
+  const generatedDocsSection = cleanedGeneratedAiDoc
+    ? `## Auto-generated tscircuit docs\n\n${cleanedGeneratedAiDoc}\n`
+    : ""
+
   return `
 You are an expert in electronic circuit design and tscircuit, and your job is to create a circuit board in tscircuit with the user-provided description.
 
 YOU MUST ABIDE BY THE RULES IN THE RULES SECTION
+
+${generatedDocsSection}
 
 ## tscircuit API overview
 

--- a/lib/tscircuit-coder/run-ai-with-error-correction.ts
+++ b/lib/tscircuit-coder/run-ai-with-error-correction.ts
@@ -1,8 +1,8 @@
-import { askAiWithPreviousAttempts } from "../ask-ai/ask-ai-with-previous-attempts"
 import { saveAttemptLog } from "lib/utils/save-attempt"
-import type OpenAI from "openai"
-import { evaluateTscircuitCode } from "../utils/evaluate-tscircuit-code"
 import { getPrimarySourceCodeFromVfs } from "lib/utils/get-primary-source-code-from-vfs"
+import type OpenAI from "openai"
+import { askAiWithPreviousAttempts } from "../ask-ai/ask-ai-with-previous-attempts"
+import { evaluateTscircuitCode } from "../utils/evaluate-tscircuit-code"
 
 const createAttemptFile = ({
   fileName,
@@ -136,5 +136,6 @@ export const runAiWithErrorCorrection = async ({
     promptNumber,
     previousAttempts,
     vfs,
+    openaiClient,
   })
 }

--- a/lib/tscircuit-coder/tscircuitCoder.ts
+++ b/lib/tscircuit-coder/tscircuitCoder.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "node:events"
+import { createLocalCircuitPrompt } from "lib/prompt-templates/create-local-circuit-prompt"
 import type { OpenAI } from "openai"
 import { runAiWithErrorCorrection } from "./run-ai-with-error-correction"
-import { createLocalCircuitPrompt } from "lib/prompt-templates/create-local-circuit-prompt"
 
 export interface TscircuitCoderEvents {
   streamedChunk: string
@@ -70,6 +70,7 @@ export class TscircuitCoderImpl extends EventEmitter implements TscircuitCoder {
       onStream,
       onVfsChanged,
       vfs: this.vfs,
+      openaiClient: this.openaiClient,
     })
     if (result.code) {
       const filepath = `prompt-${promptNumber}-attempt-final.tsx`

--- a/lib/utils/generate-random-prompts.ts
+++ b/lib/utils/generate-random-prompts.ts
@@ -1,9 +1,24 @@
 import { openai } from "lib/ai/openai"
 
+type PromptGenerationClient = {
+  chat: {
+    completions: {
+      create: (args: {
+        model: string
+        max_tokens: number
+        messages: Array<{ role: "user"; content: string }>
+      }) => Promise<{
+        choices: Array<{ message: { content: string | null } }>
+      }>
+    }
+  }
+}
+
 export const generateRandomPrompts = async (
   numberOfPrompts: number,
+  openaiClient: PromptGenerationClient = openai,
 ): Promise<string[]> => {
-  const completion = await openai.chat.completions.create({
+  const completion = await openaiClient.chat.completions.create({
     model: "gpt-4o-mini",
 
     max_tokens: 2048,

--- a/tests/tscircuitCoder.test.ts
+++ b/tests/tscircuitCoder.test.ts
@@ -1,11 +1,81 @@
-import { createTscircuitCoder } from "lib/tscircuit-coder/tscircuitCoder"
 import { expect, test } from "bun:test"
+import { createTscircuitCoder } from "lib/tscircuit-coder/tscircuitCoder"
 import { getPrimarySourceCodeFromVfs } from "lib/utils/get-primary-source-code-from-vfs"
+
+const circuitTemplate = (marker: string) => `
+export const StrainGaugeAmplifier = () => (
+  <board width="50mm" height="40mm">
+    <chip footprint="soic8" name="U1" pinLabels={{
+      1: "V+",
+      2: "V-",
+      3: "Ref",
+      4: "In+",
+      5: "In-",
+      6: "Out",
+      7: "Gain",
+      8: "GND",
+    }} pcbX="10mm" pcbY="10mm" />
+
+    <resistor name="R1" resistance="1k" footprint="0402" pcbX="12mm" pcbY="10mm" />
+    <resistor name="R2" resistance="1k" footprint="0402" pcbX="10mm" pcbY="12mm" />
+    <resistor name="R3" resistance="1k" footprint="0402" pcbX="10mm" pcbY="8mm" />
+    <capacitor name="C1" capacitance="100nF" footprint="0603" pcbX="10mm" pcbY="14mm" />
+
+    <trace from=".U1 > .pin4" to=".R1 > .pin1" />
+    <trace from=".U1 > .pin5" to=".R2 > .pin1" />
+    <trace from=".R1 > .pin2" to=".R2 > .pin2" />
+    <trace from=".U1 > .pin6" to=".R3 > .pin1" />
+    <trace from=".R3 > .pin2" to=".U1 > .GND" />
+    <trace from=".R3 > .pin2" to=".C1 > .pin1" />
+    <trace from=".C1 > .pin2" to=".U1 > .pin3" />
+
+    <net name="VCC" />
+    <net name="GND" />
+    {/* ${marker} */}
+  </board>
+)
+`
+
+const baseCircuitCode = circuitTemplate("bridge rectifier")
+const transistorCircuitCode = circuitTemplate("transistor")
+const tssop20CircuitCode = circuitTemplate("transistor tssop20")
+
+const createMockOpenaiClient = () =>
+  ({
+    chat: {
+      completions: {
+        create: async ({ messages, stream }: any) => {
+          const promptText =
+            messages?.find((message: any) => message.role === "user")?.content || ""
+          const normalizedPrompt = String(promptText).toLowerCase()
+
+          let code = baseCircuitCode
+          if (normalizedPrompt.includes("tssop20")) {
+            code = tssop20CircuitCode
+          } else if (normalizedPrompt.includes("transistor")) {
+            code = transistorCircuitCode
+          }
+
+          const content = `\`\`\`tsx\n${code}\n\`\`\``
+
+          if (!stream) {
+            return {
+              choices: [{ message: { content } }],
+            }
+          }
+
+          return (async function* () {
+            yield { choices: [{ delta: { content } }] }
+          })()
+        },
+      },
+    },
+  }) as any
 
 test("TscircuitCoder submitPrompt streams and updates vfs", async () => {
   const streamedChunks: string[] = []
   let vfsUpdated = false
-  const tscircuitCoder = createTscircuitCoder()
+  const tscircuitCoder = createTscircuitCoder(createMockOpenaiClient())
   tscircuitCoder.on("streamedChunk", (chunk: string) => {
     streamedChunks.push(chunk)
   })
@@ -21,14 +91,14 @@ test("TscircuitCoder submitPrompt streams and updates vfs", async () => {
     prompt: "add a transistor component",
   })
 
-  let codeWithTransistor = getPrimarySourceCodeFromVfs(tscircuitCoder.vfs)
+  const codeWithTransistor = getPrimarySourceCodeFromVfs(tscircuitCoder.vfs)
   expect(codeWithTransistor).toInclude("transistor")
 
   await tscircuitCoder.submitPrompt({
     prompt: "add a tssop20 chip",
   })
 
-  let codeWithChip = getPrimarySourceCodeFromVfs(tscircuitCoder.vfs)
+  const codeWithChip = getPrimarySourceCodeFromVfs(tscircuitCoder.vfs)
   expect(codeWithChip).toInclude("tssop20")
   expect(codeWithChip).toInclude("transistor")
 

--- a/tests/utils/generate-random-prompts.test.ts
+++ b/tests/utils/generate-random-prompts.test.ts
@@ -1,11 +1,30 @@
-import { describe, it, expect } from "bun:test"
+import { describe, expect, it } from "bun:test"
 import { generateRandomPrompts } from "../../lib/utils/generate-random-prompts"
 
 describe("generateRandomPrompts", () => {
   it("should return an array of prompts", async () => {
-    const prompts = await generateRandomPrompts(3)
+    const prompts = await generateRandomPrompts(3, {
+      chat: {
+        completions: {
+          create: async () => ({
+            choices: [
+              {
+                message: {
+                  content: [
+                    "1. Build a bridge rectifier with filtering",
+                    "2. Create a buck converter with current sensing",
+                    "3. Design a low-noise op-amp stage",
+                  ].join("\n"),
+                },
+              },
+            ],
+          }),
+        },
+      },
+    })
 
     expect(Array.isArray(prompts)).toBe(true)
     expect(prompts.length).toBe(3)
+    expect(prompts[0]).toContain("bridge rectifier")
   })
 })


### PR DESCRIPTION
## Summary
- fetch `https://docs.tscircuit.com/ai.txt` inside `createLocalCircuitPrompt`
- prepend the generated docs block into the system prompt when available
- make remote-doc fetch failures non-fatal so prompt generation still succeeds

This directly wires the new generated docs into prompt construction while keeping prompt creation resilient.

/claim #45