### PR TITLE
Include generated docs in local circuit prompt

### DIFF
--- a/lib/prompt-templates/create-local-circuit-prompt.ts
+++ b/lib/prompt-templates/create-local-circuit-prompt.ts
@@ -19,6 +19,15 @@ async function fetchFileContent(url: string): Promise<string> {
   }
 }
 
+function cleanMarkdownDoc(markdown: string): string {
+  return markdown
+    .split("\n")
+    .filter((line) => !line.startsWith("#"))
+    .join("\n")
+    .replace(/\n\n+/g, "\n\n")
+    .trim()
+}
+
 export const createLocalCircuitPrompt = async () => {
   const footprintNamesByType = getFootprintNamesByType()
   const footprintSizes = getFootprintSizes()
@@ -38,11 +47,12 @@ export const createLocalCircuitPrompt = async () => {
       "https://raw.githubusercontent.com/tscircuit/props/main/generated/COMPONENT_TYPES.md",
     )) || ""
 
-  const cleanedPropsDoc = propsDoc
-    .split("\n")
-    .filter((line) => !line.startsWith("#"))
-    .join("\n")
-    .replace(/\n\n+/g, "\n\n")
+  const cleanedPropsDoc = cleanMarkdownDoc(propsDoc)
+
+  const generatedDocs =
+    (await fetchFileContent("https://docs.tscircuit.com/ai.txt")) || ""
+
+  const cleanedGeneratedDocs = cleanMarkdownDoc(generatedDocs)
 
   return `
 You are an expert in electronic circuit design and tscircuit, and your job is to create a circuit board in tscircuit with the user-provided description.
@@ -117,6 +127,13 @@ keep in mind that num_pins can be replaced with a number directly infront of the
 - Here is a documentation of all available components and their types:
 
 ${cleanedPropsDoc}
+
+### Generated tscircuit docs
+
+Use these generated docs as the newest source of truth for APIs, component
+usage, examples, and current tscircuit guidance:
+
+${cleanedGeneratedDocs}
 
 - Here is a list of unsupported components: 
 

--- a/tests/prompt-templates/create-local-circuit-prompt.test.ts
+++ b/tests/prompt-templates/create-local-circuit-prompt.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, expect, test } from "bun:test"
+import { createLocalCircuitPrompt } from "lib/prompt-templates/create-local-circuit-prompt"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+test("createLocalCircuitPrompt includes generated tscircuit docs", async () => {
+  const fetchedUrls: string[] = []
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = input.toString()
+    fetchedUrls.push(url)
+
+    if (url.endsWith("/ai.txt")) {
+      return new Response("# AI docs\n\nGenerated docs marker\n\n<resistor />")
+    }
+
+    return new Response("# Props\n\n<board />\n\n<chip />")
+  }) as typeof fetch
+
+  const prompt = await createLocalCircuitPrompt()
+
+  expect(fetchedUrls).toContain("https://docs.tscircuit.com/ai.txt")
+  expect(prompt).toContain("### Generated tscircuit docs")
+  expect(prompt).toContain("Generated docs marker")
+  expect(prompt).toContain("<resistor />")
+})


### PR DESCRIPTION
Fixes #45

Includes the generated docs feed from https://docs.tscircuit.com/ai.txt in createLocalCircuitPrompt, alongside the existing generated props docs. I also extracted the markdown cleanup so both generated sources are normalized consistently.

Validation:
- npx bun test tests/prompt-templates/create-local-circuit-prompt.test.ts
- npx --yes --package typescript tsc --noEmit

Note: full `npx bun test` still hits existing unrelated AI-dependent tests that require an OpenAI API key / mocked coder output.