### PR TITLE
Include generated docs in local circuit prompt

### DIFF
--- a/lib/prompt-templates/create-local-circuit-prompt.ts
+++ b/lib/prompt-templates/create-local-circuit-prompt.ts
@@ -19,6 +19,24 @@ async function fetchFileContent(url: string): Promise<string> {
   }
 }
 
+let generatedDocsCache: string | null = null
+
+export const __resetGeneratedDocsCacheForTests = () => {
+  generatedDocsCache = null
+}
+
+async function getGeneratedDocsContent(): Promise<string> {
+  if (generatedDocsCache !== null) return generatedDocsCache
+
+  try {
+    generatedDocsCache = await fetchFileContent("https://docs.tscircuit.com/ai.txt")
+  } catch {
+    generatedDocsCache = ""
+  }
+
+  return generatedDocsCache
+}
+
 export const createLocalCircuitPrompt = async () => {
   const footprintNamesByType = getFootprintNamesByType()
   const footprintSizes = getFootprintSizes()
@@ -43,6 +61,7 @@ export const createLocalCircuitPrompt = async () => {
     .filter((line) => !line.startsWith("#"))
     .join("\n")
     .replace(/\n\n+/g, "\n\n")
+  const generatedDocsContent = await getGeneratedDocsContent()
 
   return `
 You are an expert in electronic circuit design and tscircuit, and your job is to create a circuit board in tscircuit with the user-provided description.
@@ -52,6 +71,8 @@ YOU MUST ABIDE BY THE RULES IN THE RULES SECTION
 ## tscircuit API overview
 
 Here's an overview of the tscircuit API:
+
+${generatedDocsContent ? `## Auto-generated tscircuit docs\n\n${generatedDocsContent}` : ""}
 
 <board width="10mm" height="10mm" /> // usually the root component
 <board outline={[{x: 0, y: 0}, {x: 10, y: 0}, {x: 10, y: 10}, {x: 0, y: 10}]} /> // custom shape instead of rectangle

--- a/tests/create-local-circuit-prompt.test.ts
+++ b/tests/create-local-circuit-prompt.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, expect, test } from "bun:test"
+import {
+  __resetGeneratedDocsCacheForTests,
+  createLocalCircuitPrompt,
+} from "../lib/prompt-templates/create-local-circuit-prompt"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  __resetGeneratedDocsCacheForTests()
+})
+
+test("includes generated docs when ai.txt is available", async () => {
+  globalThis.fetch = async (url) =>
+    new Response(
+      url.toString().includes("ai.txt")
+        ? "Generated docs content"
+        : "# Component Types\n\ncomponent props content",
+    )
+
+  const prompt = await createLocalCircuitPrompt()
+
+  expect(prompt).toContain("## Auto-generated tscircuit docs")
+  expect(prompt).toContain("Generated docs content")
+  expect(prompt).toContain("component props content")
+})
+
+test("keeps prompt creation working when generated docs fail", async () => {
+  globalThis.fetch = async (url) => {
+    if (url.toString().includes("ai.txt")) {
+      throw new Error("docs unavailable")
+    }
+
+    return new Response("# Component Types\n\ncomponent props content")
+  }
+
+  const prompt = await createLocalCircuitPrompt()
+
+  expect(prompt).not.toContain("## Auto-generated tscircuit docs")
+  expect(prompt).toContain("component props content")
+})


### PR DESCRIPTION
/claim #45

This adds the generated docs from `https://docs.tscircuit.com/ai.txt` to the local circuit prompt, while keeping prompt creation safe if that docs endpoint is down.

I kept the change small and added focused tests for both paths:
- generated docs are included when `ai.txt` is available
- prompt creation still works when `ai.txt` cannot be fetched

Checked locally:
- `bun test tests/create-local-circuit-prompt.test.ts`
- `biome check lib/prompt-templates/create-local-circuit-prompt.ts tests/create-local-circuit-prompt.test.ts`
- `tsc --noEmit --pretty false`