### PR TITLE
Include generated docs in local circuit prompt

### DIFF
--- a/lib/prompt-templates/create-local-circuit-prompt.ts
+++ b/lib/prompt-templates/create-local-circuit-prompt.ts
@@ -1,7 +1,7 @@
 import {
+  fp,
   getFootprintNamesByType,
   getFootprintSizes,
-  fp,
 } from "@tscircuit/footprinter"
 
 async function fetchFileContent(url: string): Promise<string> {
@@ -19,6 +19,23 @@ async function fetchFileContent(url: string): Promise<string> {
   }
 }
 
+let generatedDocsPromise: Promise<string> | null = null
+
+export function resetGeneratedDocsCacheForTests() {
+  generatedDocsPromise = null
+}
+
+async function fetchGeneratedDocs(): Promise<string> {
+  generatedDocsPromise ??= fetchFileContent("https://docs.tscircuit.com/ai.txt")
+    .then((content) => content.trim())
+    .catch((error) => {
+      console.error("Error fetching generated docs:", error)
+      return ""
+    })
+
+  return generatedDocsPromise
+}
+
 export const createLocalCircuitPrompt = async () => {
   const footprintNamesByType = getFootprintNamesByType()
   const footprintSizes = getFootprintSizes()
@@ -33,16 +50,28 @@ export const createLocalCircuitPrompt = async () => {
     "",
   )
 
-  const propsDoc =
-    (await fetchFileContent(
+  const [propsDoc, generatedDocs] = await Promise.all([
+    fetchFileContent(
       "https://raw.githubusercontent.com/tscircuit/props/main/generated/COMPONENT_TYPES.md",
-    )) || ""
+    ),
+    fetchGeneratedDocs(),
+  ])
 
   const cleanedPropsDoc = propsDoc
     .split("\n")
     .filter((line) => !line.startsWith("#"))
     .join("\n")
     .replace(/\n\n+/g, "\n\n")
+
+  const generatedDocsSection = generatedDocs
+    ? `
+### Auto-generated tscircuit docs
+
+Use this generated docs reference when it has newer guidance than the hand-written examples above:
+
+${generatedDocs}
+`
+    : ""
 
   return `
 You are an expert in electronic circuit design and tscircuit, and your job is to create a circuit board in tscircuit with the user-provided description.
@@ -117,6 +146,7 @@ keep in mind that num_pins can be replaced with a number directly infront of the
 - Here is a documentation of all available components and their types:
 
 ${cleanedPropsDoc}
+${generatedDocsSection}
 
 - Here is a list of unsupported components: 
 

--- a/tests/create-local-circuit-prompt.test.ts
+++ b/tests/create-local-circuit-prompt.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, expect, test } from "bun:test"
+import {
+  createLocalCircuitPrompt,
+  resetGeneratedDocsCacheForTests,
+} from "lib/prompt-templates/create-local-circuit-prompt"
+
+const originalFetch = globalThis.fetch
+const originalConsoleError = console.error
+
+beforeEach(() => {
+  resetGeneratedDocsCacheForTests()
+  console.error = () => {}
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  console.error = originalConsoleError
+})
+
+test("includes generated docs from ai.txt in the local circuit prompt", async () => {
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = input.toString()
+
+    if (url === "https://docs.tscircuit.com/ai.txt") {
+      return new Response("Use <resistor /> with resistance and footprint.")
+    }
+
+    if (url.includes("COMPONENT_TYPES.md")) {
+      return new Response("# Components\n\n<resistor /> props")
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`)
+  }
+
+  const prompt = await createLocalCircuitPrompt()
+
+  expect(prompt).toContain("### Auto-generated tscircuit docs")
+  expect(prompt).toContain("Use <resistor /> with resistance and footprint.")
+  expect(prompt).toContain("<resistor /> props")
+})
+
+test("keeps prompt generation working when generated docs cannot be fetched", async () => {
+  globalThis.fetch = async (input: RequestInfo | URL) => {
+    const url = input.toString()
+
+    if (url === "https://docs.tscircuit.com/ai.txt") {
+      return new Response("missing", { status: 500, statusText: "Error" })
+    }
+
+    if (url.includes("COMPONENT_TYPES.md")) {
+      return new Response("# Components\n\n<capacitor /> props")
+    }
+
+    throw new Error(`Unexpected fetch: ${url}`)
+  }
+
+  const prompt = await createLocalCircuitPrompt()
+
+  expect(prompt).not.toContain("### Auto-generated tscircuit docs")
+  expect(prompt).toContain("<capacitor /> props")
+})


### PR DESCRIPTION
## Summary

- load `https://docs.tscircuit.com/ai.txt` as optional generated-doc context for `createLocalCircuitPrompt`
- fetch generated docs in parallel with the existing component props docs
- cache generated docs during the process and keep prompt generation resilient if the endpoint fails
- omit the generated-docs section when the optional endpoint is unavailable, instead of leaving an empty prompt section
- add deterministic mocked-fetch tests for inclusion and fallback behavior

Fixes #45

## Verification

```text
bun test tests/create-local-circuit-prompt.test.ts
2 pass
0 fail
5 expect() calls

biome check lib/prompt-templates/create-local-circuit-prompt.ts tests/create-local-circuit-prompt.test.ts
Checked 2 files. No fixes applied.

node node_modules/typescript/bin/tsc --noEmit --pretty false

node node_modules/tsup/dist/cli-node.js lib/index.ts --format esm --dts
Build success
```

/claim #45