### PR TITLE
Use generated props overview in circuit prompt

### DIFF
--- a/lib/prompt-templates/create-local-circuit-prompt.ts
+++ b/lib/prompt-templates/create-local-circuit-prompt.ts
@@ -4,6 +4,12 @@ import {
   fp,
 } from "@tscircuit/footprinter"
 
+export const GENERATED_PROPS_DOC_URL =
+  "https://raw.githubusercontent.com/tscircuit/props/main/generated/COMPONENT_TYPES.md"
+
+export const GENERATED_PROPS_OVERVIEW_URL =
+  "https://raw.githubusercontent.com/tscircuit/props/main/generated/PROPS_OVERVIEW.md"
+
 async function fetchFileContent(url: string): Promise<string> {
   try {
     const response = await fetch(url)
@@ -17,6 +23,15 @@ async function fetchFileContent(url: string): Promise<string> {
     console.error("Error fetching file content:", error)
     throw error
   }
+}
+
+export function cleanGeneratedDoc(doc: string): string {
+  return doc
+    .split("\n")
+    .filter((line) => !line.startsWith("#"))
+    .join("\n")
+    .replace(/\n\n+/g, "\n\n")
+    .trim()
 }
 
 export const createLocalCircuitPrompt = async () => {
@@ -33,16 +48,13 @@ export const createLocalCircuitPrompt = async () => {
     "",
   )
 
-  const propsDoc =
-    (await fetchFileContent(
-      "https://raw.githubusercontent.com/tscircuit/props/main/generated/COMPONENT_TYPES.md",
-    )) || ""
+  const [propsDoc, propsOverviewDoc] = await Promise.all([
+    fetchFileContent(GENERATED_PROPS_DOC_URL),
+    fetchFileContent(GENERATED_PROPS_OVERVIEW_URL),
+  ])
 
-  const cleanedPropsDoc = propsDoc
-    .split("\n")
-    .filter((line) => !line.startsWith("#"))
-    .join("\n")
-    .replace(/\n\n+/g, "\n\n")
+  const cleanedPropsDoc = cleanGeneratedDoc(propsDoc)
+  const cleanedPropsOverviewDoc = cleanGeneratedDoc(propsOverviewDoc)
 
   return `
 You are an expert in electronic circuit design and tscircuit, and your job is to create a circuit board in tscircuit with the user-provided description.
@@ -114,7 +126,14 @@ keep in mind that num_pins can be replaced with a number directly infront of the
 
 ### Components and Props
 
-- Here is a documentation of all available components and their types:
+- Here is the auto-generated props overview. Prefer these prop names and
+  component capabilities when deciding how to express layouts, footprints,
+  ports, nets, silkscreen, constraints, and PCB placement:
+
+${cleanedPropsOverviewDoc}
+
+- Here is the auto-generated documentation of all available components and
+  their types:
 
 ${cleanedPropsDoc}
 

--- a/tests/prompt-templates/create-local-circuit-prompt.test.ts
+++ b/tests/prompt-templates/create-local-circuit-prompt.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, expect, test } from "bun:test"
+import {
+  GENERATED_PROPS_DOC_URL,
+  GENERATED_PROPS_OVERVIEW_URL,
+  cleanGeneratedDoc,
+  createLocalCircuitPrompt,
+} from "../../lib/prompt-templates/create-local-circuit-prompt"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+})
+
+test("cleanGeneratedDoc strips markdown headings and collapses blank lines", () => {
+  expect(cleanGeneratedDoc("# Heading\n\nbody\n\n\n## Subheading\nvalue")).toBe(
+    "body\n\nvalue",
+  )
+})
+
+test("createLocalCircuitPrompt includes generated props overview and component docs", async () => {
+  const fetchedUrls: string[] = []
+
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input)
+    fetchedUrls.push(url)
+
+    if (url === GENERATED_PROPS_OVERVIEW_URL) {
+      return new Response("# Props Overview\n\nUse pcbX for placement.")
+    }
+
+    if (url === GENERATED_PROPS_DOC_URL) {
+      return new Response("# Component Types\n\n<resistor resistance=\"1k\" />")
+    }
+
+    return new Response("not found", { status: 404 })
+  }) as typeof fetch
+
+  const prompt = await createLocalCircuitPrompt()
+
+  expect(fetchedUrls).toContain(GENERATED_PROPS_OVERVIEW_URL)
+  expect(fetchedUrls).toContain(GENERATED_PROPS_DOC_URL)
+  expect(prompt).toContain("Use pcbX for placement.")
+  expect(prompt).toContain('<resistor resistance="1k" />')
+  expect(prompt).toContain("auto-generated props overview")
+  expect(prompt).toContain("auto-generated documentation")
+})


### PR DESCRIPTION
/claim #45

## Summary
- add `PROPS_OVERVIEW.md` from `tscircuit/props/generated` to the local circuit system prompt alongside `COMPONENT_TYPES.md`
- centralize generated-doc cleanup so both generated docs are stripped of markdown headings and collapsed consistently
- add focused Bun tests for doc cleanup and prompt inclusion of both generated docs

## Verification
- `git diff --check`

I could not run `bun test` locally in this Codex environment because this session only has `node.exe` available and no `bun`/`npm` executable in PATH. The new test is included for CI/local Bun verification.