### PR TITLE
use the new auto generated docs in the system prompt

### DIFF
--- a/lib/prompt-templates/create-local-circuit-prompt.ts
+++ b/lib/prompt-templates/create-local-circuit-prompt.ts
@@ -35,7 +35,11 @@ export const createLocalCircuitPrompt = async () => {
 
   const propsDoc =
     (await fetchFileContent(
-      "https://raw.githubusercontent.com/tscircuit/props/main/generated/COMPONENT_TYPES.md",
+      "https://raw.githubusercontent.com/tscircuit/props/main/generated/COMPONENT_DOCS.md",
+    ).catch(() =>
+      fetchFileContent(
+        "https://raw.githubusercontent.com/tscircuit/props/main/generated/COMPONENT_TYPES.md",
+      ),
     )) || ""
 
   const cleanedPropsDoc = propsDoc


### PR DESCRIPTION
Closes the [bounty](https://github.com/tscircuit/prompt-benchmarks/issues/45).

## Summary

Summary: Update create-local-circuit-prompt to fetch from the new auto-generated COMPONENT_DOCS.md with fallback to the old COMPONENT_TYPES.md

Reasoning: The issue asks to use new auto-generated docs in the system prompt. The existing code fetches COMPONENT_TYPES.md (raw zod/TypeScript type definitions) from the tscircuit/props repo. The new auto-generated docs are in COMPONENT_DOCS.md in the same repo, which provides more readable documentation. A fallback to the old URL is included so the prompt still works if the new file is not yet available.

Top blockers: Cannot confirm the exact URL of the new auto-generated docs without seeing the tscircuit/props repo structure or the referenced image in the issue. The URL COMPONENT_DOCS.md is an educated guess based on naming conventions.

## Test commands

- `bun test tests/utils/save-prompt.test.ts`
- `bun test`

---
_Submitted via bounty-bot. Confidence: low._